### PR TITLE
fix: Changed curseforge update ids to integers

### DIFF
--- a/src/schemas/json/packwiz-mod.json
+++ b/src/schemas/json/packwiz-mod.json
@@ -92,11 +92,11 @@
           "properties": {
             "file-id": {
               "description": "An integer representing the unique file ID of this mod file. This can be used if more metadata needs to be obtained relating to the mod.",
-              "type": "number"
+              "type": "integer"
             },
             "project-id": {
               "description": "An integer representing the unique project ID of this mod. Updating will retrieve the latest file for this project ID that is valid (correct Minecraft version, release channel, modloader, etc.).",
-              "type": "number"
+              "type": "integer"
             }
           },
           "x-taplo": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the contributing guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
-->

Hey, this PR probably comes kinda out of the blue, but I saw your packwiz schemas in an issue in the packwiz repo and wanted to use them for some type generation, but realized that the project id and file id in the curseforge update source generated floating point types instead of integers.
`integer` does seem like the more correct type here, so I decided to fix it: https://json-schema.org/understanding-json-schema/reference/numeric#integer

I'm not sure if this affects the tests in any way, and I don't know how to manually run them, so sorry if this should have been changed in some other place in the code too